### PR TITLE
Change FIXME links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ and to meet some of our community members.
 ## Where to Contribute
 
 1.  If you wish to change this lesson,
-    please work in <https://github.com/swcarpentry/FIXME>,
-    which can be viewed at <https://swcarpentry.github.io/FIXME>.
+    please work in https://github.com/LibraryCarpentry/lc-overview/,
+    which can be viewed at https://librarycarpentry.org/lc-overview/.
 
 2.  If you wish to change the example lesson,
     please work in <https://github.com/swcarpentry/lesson-example>,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ and to meet some of our community members.
 ## Where to Contribute
 
 1.  If you wish to change this lesson,
-    please work in https://github.com/LibraryCarpentry/lc-overview/,
-    which can be viewed at https://librarycarpentry.org/lc-overview/.
+    please work in <https://github.com/LibraryCarpentry/lc-overview/>,
+    which can be viewed at <https://librarycarpentry.org/lc-overview/>.
 
 2.  If you wish to change the example lesson,
     please work in <https://github.com/swcarpentry/lesson-example>,


### PR DESCRIPTION
There were two "FIXME" links listed. This change switches them to the repository and the lesson page, respectively.