### PR TITLE
(workbench fix) make block quotes complete

### DIFF
--- a/_episodes/03-jargon-busting.md
+++ b/_episodes/03-jargon-busting.md
@@ -16,14 +16,14 @@ keypoints:
 >
 > This exercise is an opportunity to gain a firmer grasp on the concepts around data, code or software development in libraries.
 >
-1. Pair with a neighbor and decide who will take notes (or depending on the amount of time available for the exercise, skip to forming groups of four to six). 
-1. Talk for three minutes (your instructor will be timing you!) on any terms, phrases, or ideas around code or software development in libraries that you've come across and perhaps feel you should know better.
-1. Next, get into groups of four to six.
-1. Make a list of all the problematic terms, phrases, and ideas each pair came up with. Retain duplicates.
-1. Identify common words as a starting point - spend 10 minutes working together to try to explain what the terms, phrases, or ideas on your list mean.  Note: use both each other and the internet as a resource.
-1. Identify the terms your groups were able to explain as well as those you are still struggling with.
-1. Each group then reports back on one issue resolved by their group and one issue not resolved by their group.
-1. The instructor will collate these on a whiteboard and facilitate a discussion about what we will cover today and where you can go for help on those things we won't cover. Any jargon or terms that will not be covered specifically are good notes.
+> 1. Pair with a neighbor and decide who will take notes (or depending on the amount of time available for the exercise, skip to forming groups of four to six). 
+> 1. Talk for three minutes (your instructor will be timing you!) on any terms, phrases, or ideas around code or software development in libraries that you've come across and perhaps feel you should know better.
+> 1. Next, get into groups of four to six.
+> 1. Make a list of all the problematic terms, phrases, and ideas each pair came up with. Retain duplicates.
+> 1. Identify common words as a starting point - spend 10 minutes working together to try to explain what the terms, phrases, or ideas on your list mean.  Note: use both each other and the internet as a resource.
+> 1. Identify the terms your groups were able to explain as well as those you are still struggling with.
+> 1. Each group then reports back on one issue resolved by their group and one issue not resolved by their group.
+> 1. The instructor will collate these on a whiteboard and facilitate a discussion about what we will cover today and where you can go for help on those things we won't cover. Any jargon or terms that will not be covered specifically are good notes.
 {: .challenge}
 
 
@@ -32,8 +32,8 @@ keypoints:
 > Often, workshop attendees ask if there is a handout of common terms and definitions as there is not enough time to explain all the terms in a jargon busting exercise. Many of the terms are covered in our lessons such as Application Programming Interface (API), regular expressions, terminal, git... but with so much [variation between our jargon busting sessions](https://twitter.com/search?q=jargon%20libcarpentry&src=typed_query&f=live), it is difficult to create a common handout. You can start with resources such as [TechTerms](https://techterms.com/category/technical) or the [Data Thesaurus](https://nnlm.gov/data/thesaurus) but you may also need to use the internet to explain terms. The [Sideways Dictionary](https://sidewaysdictionary.com) is another great place to get examples of jargon explained in plain English.  
 >  
 >  
-Keep in mind that our goal is not to explain all the terms we list out in the exercise, but instead to highlight how much jargon we use in our daily work and to come up with a shared understanding for a select number of jargon terms. 
+> Keep in mind that our goal is not to explain all the terms we list out in the exercise, but instead to highlight how much jargon we use in our daily work and to come up with a shared understanding for a select number of jargon terms. 
 >  
 >  
-If you do have a helpful handout that you would like to share, please submit an [issue/pull request](https://github.com/LibraryCarpentry/lc-data-intro) to this lesson. 
+> If you do have a helpful handout that you would like to share, please submit an [issue/pull request](https://github.com/LibraryCarpentry/lc-data-intro) to this lesson. 
 {: .callout}


### PR DESCRIPTION
I was having issues converting this lesson to use The Workbench (see https://github.com/carpentries/lesson-transition/issues/83).

This will fix that issue. Merging this sooner will help me prepare a preview for you before the transition in May.

For what it's worth, this pattern of writing callout blocks inside of block quotes will go away with The Workbench: https://carpentries.github.io/workbench/transition-guide.html#callout-blocks



